### PR TITLE
Update runner improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The score is calculated by summing up every valid PB of a user according to a fo
 4. 80th percentile soft cutoff: Find the time that's most often repeated in the leaderboard (at least thrice, after the 80th percentile) and cut off everything after that. This is for runs where there's a lot of similar times near the end of the leaderboard. We consider such times to be a "soft maximum limit". (Either because it's impossible to do worse, or because you may have to intentionally go slow)
 From this step onward, the amount of runners in the leaderboard will be reffered to as the "population". Except for step #5.3 where the lowest deviation is be taken from before the cutoff.  
 Note: The soft cutoff works great on games such as Barney. But is too punishing on games such as Mario 1. To be improved.
-5. Generate a logaritmic curve that looks somewhat like below. Where the average time = e-1 and the last run is worth 0  
+5. Generate a logaritmic curve that looks somewhat like below. Where the average time ≤ e-1 and the last run is worth 0  
 ![Curve Example](/assets/images/Curve%20example.jpg)
     - 5.1. A signed deviation is obtained for all the runs
     - 5.2. The deviation is adjusted so that the last run is worth 0 points. By adding the lowest (unsigned) deviation to the signed deviation
@@ -45,8 +45,8 @@ Note: The soft cutoff works great on games such as Barney. But is too punishing 
     - `length_bonus = 1 + (wr_time / TIME_BONUS_DIVISOR)`. This is to slightly bonify longuer runs which which usually require more time put in the game to achieve a similar level of execution
         - `TIME_BONUS_DIVISOR = 3600 * 12`: 12h (1/2 day) for +100%
 7. If the run is an IL (Individual Level), the points are divided by "the quantity of ILs for the game + 1" (`points / (level_count + 1)`)
-8. Finally, while all currently valid personal bests will be shown, only the top 100 will be counted in order to help reduce the "quantity over quality" game.
-    - Since Ils are only worth a fraction, they are also weighted a fraction of the top 100. Full Games are always 1 spot.
+8. Finally, while all currently valid personal bests will be shown, only the top 60 will be counted in order to help reduce the "quantity over quality" game.
+    - Since Ils are only worth a fraction, they are also weighted a fraction of the top 60. Full Games are always 1 spot.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,26 +27,25 @@ The score is calculated by summing up every valid PB of a user according to a fo
     - The leaderboard (for the current sub-category) has at least 3 runs
     - Is part of a speedrun leaderboard, not a scoreboard
     - The WR time is not under a minute
-        - ILs' WR should not be under their fraction of a minute (see step #8)
-    - After step #5, not all runs have the same time
-2. Due to current limitations with PythonAnywhere and the speedrun.com api, only up to the last 1000 runs will be kept.
-3. All runs not considered valid (w/o video/image verification or banned user) are removed from the leaderboard and can be considered as non-existant from now on.
-4. Remove the last 5% of the leaderboard
-5. 80th percentile soft cutoff: Find the time that's most often repeated in the leaderboard (at least thrice, after the 80th percentile) and cut off everything after that. This is for runs where there's a lot of similar times near the end of the leaderboard. We consider such times to be a "soft maximum limit". (Either because it's impossible to do worse, or because you may have to intentionally go slow)
-From this step onward, the amount of runners in the leaderboard will be reffered to as the "population". Except for step #6.3 where the lowest deviation is be taken from before the cutoff.  
+        - ILs' WR should not be under their fraction of a minute (see step #7)
+    - After step #4, not all runs have the same time
+2. All runs not considered valid (w/o video/image verification or banned user) are removed from the leaderboard and can be considered as non-existant from now on.
+3. Remove the last 5% of the leaderboard
+4. 80th percentile soft cutoff: Find the time that's most often repeated in the leaderboard (at least thrice, after the 80th percentile) and cut off everything after that. This is for runs where there's a lot of similar times near the end of the leaderboard. We consider such times to be a "soft maximum limit". (Either because it's impossible to do worse, or because you may have to intentionally go slow)
+From this step onward, the amount of runners in the leaderboard will be reffered to as the "population". Except for step #5.3 where the lowest deviation is be taken from before the cutoff.  
 Note: The soft cutoff works great on games such as Barney. But is too punishing on games such as Mario 1. To be improved.
-6. Generate a logaritmic curve that looks somewhat like below. Where the average time = 1 and the last run is worth 0  
+5. Generate a logaritmic curve that looks somewhat like below. Where the average time = 1 and the last run is worth 0  
 ![Curve Example](/assets/images/Curve%20example.jpg)
-    - 6.1. A signed standart deviation is obtained for all the runs
-    - 6.2. The deviation is adjusted so that the last run is worth 0 points. By adding the lowest (unsigned) deviation to the signed deviation
-    - 6.3. The deviation is then normalized so that the average time is worth 1 point and the last run is still worth 0 points. By dividing the adjusted deviation with the adjusted lowest deviation. Capped at π.
-    - 6.4. Points for a run are equal to: `e^(normalized_deviation * certainty_adjustment)`
+    - 5.1. A signed standart deviation is obtained for all the runs
+    - 5.2. The deviation is adjusted so that the last run is worth 0 points. By adding the lowest (unsigned) deviation to the signed deviation
+    - 5.3. The deviation is then normalized so that the average time is worth 1 point and the last run is still worth 0 points. By dividing the adjusted deviation with the adjusted lowest deviation. Capped at π.
+    - 5.4. Points for a run are equal to: `e^(normalized_deviation * certainty_adjustment) -1`
         - `certainty_adjustment = 1 - 1 / (population - 1)`
-7. The points for a run are then multiplied by a "length bonus", the decimal point is shifted to the right by 1 and is capped at 999.99
+6. The points for a run are then multiplied by a "length bonus", the decimal point is shifted to the right by 1 and is capped at 999.99
     - `length_bonus = 1 + (wr_time / TIME_BONUS_DIVISOR)`. This is to slightly bonify longuer runs which which usually require more time put in the game to achieve a similar level of execution
         - `TIME_BONUS_DIVISOR = 3600 * 12`: 12h (1/2 day) for +100%
-8. If the run is an IL (Individual Level), the points are divided by "the quantity of ILs for the game + 1" (`1 / (level_count + 1)`)
-9. Finally, while all currently valid personal bests will be shown, only the top 100 will be counted in order to help reduce the "quantity over quality" game.
+7. If the run is an IL (Individual Level), the points are divided by "the quantity of ILs for the game + 1" (`1 / (level_count + 1)`)
+8. Finally, while all currently valid personal bests will be shown, only the top 100 will be counted in order to help reduce the "quantity over quality" game.
     - Since Ils are only worth a fraction, they are also weighted a fraction of the top 100. Full Games are always 1 spot.
 
 ---

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ The score is calculated by summing up every valid PB of a user according to a fo
 4. 80th percentile soft cutoff: Find the time that's most often repeated in the leaderboard (at least thrice, after the 80th percentile) and cut off everything after that. This is for runs where there's a lot of similar times near the end of the leaderboard. We consider such times to be a "soft maximum limit". (Either because it's impossible to do worse, or because you may have to intentionally go slow)
 From this step onward, the amount of runners in the leaderboard will be reffered to as the "population". Except for step #5.3 where the lowest deviation is be taken from before the cutoff.  
 Note: The soft cutoff works great on games such as Barney. But is too punishing on games such as Mario 1. To be improved.
-5. Generate a logaritmic curve that looks somewhat like below. Where the average time = 1 and the last run is worth 0  
+5. Generate a logaritmic curve that looks somewhat like below. Where the average time = e-1 and the last run is worth 0  
 ![Curve Example](/assets/images/Curve%20example.jpg)
-    - 5.1. A signed standart deviation is obtained for all the runs
+    - 5.1. A signed deviation is obtained for all the runs
     - 5.2. The deviation is adjusted so that the last run is worth 0 points. By adding the lowest (unsigned) deviation to the signed deviation
     - 5.3. The deviation is then normalized so that the average time is worth 1 point and the last run is still worth 0 points. By dividing the adjusted deviation with the adjusted lowest deviation. Capped at π.
-    - 5.4. Points for a run are equal to: `e^(normalized_deviation * certainty_adjustment) -1`
+    - 5.4. Points for a run are equal to: `e^(normalized_deviation * certainty_adjustment) -1` which creates the logarithmic curve that starts at 0
         - `certainty_adjustment = 1 - 1 / (population - 1)`
-6. The points for a run are then multiplied by a "length bonus", the decimal point is shifted to the right by 1 and is capped at 999.99
+6. The points for a run are then multiplied by a "length bonus" and the decimal point is shifted to the right by 1.
     - `length_bonus = 1 + (wr_time / TIME_BONUS_DIVISOR)`. This is to slightly bonify longuer runs which which usually require more time put in the game to achieve a similar level of execution
         - `TIME_BONUS_DIVISOR = 3600 * 12`: 12h (1/2 day) for +100%
-7. If the run is an IL (Individual Level), the points are divided by "the quantity of ILs for the game + 1" (`1 / (level_count + 1)`)
+7. If the run is an IL (Individual Level), the points are divided by "the quantity of ILs for the game + 1" (`points / (level_count + 1)`)
 8. Finally, while all currently valid personal bests will be shown, only the top 100 will be counted in order to help reduce the "quantity over quality" game.
     - Since Ils are only worth a fraction, they are also weighted a fraction of the top 100. Full Games are always 1 spot.
 

--- a/configs.template.py
+++ b/configs.template.py
@@ -4,14 +4,17 @@ from typing import List
 # We're only doing it here because it's annoying to invalidate JWT tokens on refresh during development
 secret_key: bytes = bytes([1])  # os.urandom(16)
 
+# Flask settings
 debug: bool = True
 flask_environment: str = "development"
 allow_cors: bool = True
+auto_reload_templates: bool = True
+
+# Custom settings
 bypass_update_restrictions: bool = True
 last_updated_days: List[int] = [7, 30, 91]
 # Timezone: https://momentjs.com/timezone/#format-dates-in-any-timezone
 server_timezone: str = "America/New_York"
-auto_reload_templates: bool = True
 
 # Database settings
 sql_track_modifications: bool = False

--- a/global-scoreboard/src/Dashboard/UpdateMessage.tsx
+++ b/global-scoreboard/src/Dashboard/UpdateMessage.tsx
@@ -16,11 +16,16 @@ const minutes5 = 5_000 * 60
 let progressTimer: NodeJS.Timeout
 let position: number
 
+const updateRunPosition = (levelFraction: number) => {
+  const precision = levelFraction < 0.1 ? 100 : 10
+  return Math.round((position += levelFraction) * precision) / precision
+}
+
 const renderRow = (rows: RunResult[]) => {
   return rows.map((row, rowi) =>
     <tr key={`row${rowi}`}>
       <td>
-        {Math.round((position += row.levelFraction) * 10) / 10}
+        {updateRunPosition(row.levelFraction)}
       </td>
       <td>
         {row.gameName} - {row.categoryName}{row.levelName ? ` (${row.levelName})` : ''}

--- a/global-scoreboard/src/Dashboard/UpdateMessage.tsx
+++ b/global-scoreboard/src/Dashboard/UpdateMessage.tsx
@@ -71,7 +71,7 @@ export const renderScoreTable = (baseString: string) => {
 
   return <>
     <div>{topMessage}</div>
-    {topRuns.length > 0 && <label>Top 100 runs:</label>}
+    {topRuns.length > 0 && <label>Top 60 runs:</label>}
     {(topRuns.length > 0 || tableElements.slice(2).length > 0) &&
       <table className="scoreDetailsTable">
         <thead>

--- a/global-scoreboard/src/Dashboard/UpdateMessage.tsx
+++ b/global-scoreboard/src/Dashboard/UpdateMessage.tsx
@@ -2,6 +2,7 @@ import { Alert, OverlayTrigger, ProgressBar, Tooltip } from 'react-bootstrap'
 import React, { useEffect, useState } from 'react'
 import { AlertProps } from 'react-bootstrap/Alert'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { RunResult } from '../models/UpdateRunnerResult'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 
 type UpdateMessageProps = {
@@ -15,7 +16,7 @@ const minutes5 = 5_000 * 60
 let progressTimer: NodeJS.Timeout
 let position: number
 
-const renderRow = (rows: any[]) => {
+const renderRow = (rows: RunResult[]) => {
   return rows.map((row, rowi) =>
     <tr key={`row${rowi}`}>
       <td>
@@ -25,7 +26,7 @@ const renderRow = (rows: any[]) => {
         {row.gameName} - {row.categoryName}{row.levelName ? ` (${row.levelName})` : ''}
       </td>
       <td>
-        {(row.points as number).toFixed(2)}
+        {row.points.toFixed(2)}
       </td>
     </tr>
   )
@@ -40,16 +41,18 @@ export const renderScoreTable = (baseString: string) => {
         .map(rowItem =>
           rowItem.trim()))
   const firstTableElement = allElements.findIndex(element => element.length === 2)
-  const topMessage = allElements
-    .slice(0, firstTableElement)
-    .reduce((prev, curr) => prev + `${curr[0]}\n`, '')
-    .trim()
+  const topMessage = firstTableElement > -1
+    ? allElements
+      .slice(0, firstTableElement > 0 ? firstTableElement : undefined)
+      .reduce((prev, curr) => prev + `${curr[0]}\n`, '')
+      .trim()
+    : allElements[0][0]
 
   // Note: TableElements is used for rendering old string formatted table
   const tableElements = allElements.slice(firstTableElement)
 
-  let topRuns: any[] = []
-  let lesserRuns: any[] = []
+  let topRuns: RunResult[] = []
+  let lesserRuns: RunResult[] = []
 
   if (tableElements.length === 1 && tableElements[0].length === 1) {
     try {
@@ -64,42 +67,44 @@ export const renderScoreTable = (baseString: string) => {
   return <>
     <div>{topMessage}</div>
     {topRuns.length > 0 && <label>Top 100 runs:</label>}
-    <table className="scoreDetailsTable">
-      <thead>
-        <tr>
-          <th>#{topRuns.length > 0 && <OverlayTrigger
-            placement="bottom"
-            overlay={
-              <Tooltip
-                id="levelFractionInfo"
-              >Individual Levels (IL) are weighted and scored to a fraction of a Full Game run. See the About page for a complete explanation.</Tooltip>
-            }
-          >
-            <FontAwesomeIcon icon={faInfoCircle} />
-          </OverlayTrigger>}</th>
-          <th>Game - Category (Level)</th>
-          <th>Points</th>
-        </tr>
-      </thead>
-      {topRuns.length > 0
-        ? <tbody>
-          {renderRow(topRuns)}
-        </tbody>
-        : <tbody>
-          {/* Note: TableElements is used for rendering old string formatted table */}
-          {tableElements.slice(2).map((row, rowi) =>
-            <tr key={`row${rowi}`}>
-              <td>{rowi + 1}</td>
-              {row.map((element, elementi) =>
-                <td key={`element${elementi}`}>
-                  {element}
-                </td>
-              )}
-            </tr>
-          )}
-        </tbody>
-      }
-    </table >
+    {(topRuns.length > 0 || tableElements.slice(2).length > 0) &&
+      <table className="scoreDetailsTable">
+        <thead>
+          <tr>
+            <th>#{topRuns.length > 0 && <OverlayTrigger
+              placement="bottom"
+              overlay={
+                <Tooltip
+                  id="levelFractionInfo"
+                >Individual Levels (IL) are weighted and scored to a fraction of a Full Game run. See the About page for a complete explanation.</Tooltip>
+              }
+            >
+              <FontAwesomeIcon icon={faInfoCircle} />
+            </OverlayTrigger>}</th>
+            <th>Game - Category (Level)</th>
+            <th>Points</th>
+          </tr>
+        </thead>
+        {topRuns.length > 0
+          ? <tbody>
+            {renderRow(topRuns)}
+          </tbody>
+          : <tbody>
+            {/* Note: TableElements is used for rendering old string formatted table */}
+            {tableElements.slice(2).map((row, rowi) =>
+              <tr key={`row${rowi}`}>
+                <td>{rowi + 1}</td>
+                {row.map((element, elementi) =>
+                  <td key={`element${elementi}`}>
+                    {element}
+                  </td>
+                )}
+              </tr>
+            )}
+          </tbody>
+        }
+      </table>
+    }
     {lesserRuns.length > 0 && <>
       <br />
       <label>Other runs:</label>

--- a/global-scoreboard/src/models/UpdateRunnerResult.ts
+++ b/global-scoreboard/src/models/UpdateRunnerResult.ts
@@ -4,3 +4,11 @@ export default interface UpdateRunnerResult extends Player {
   state?: AlertProps['variant']
   message: string
 }
+
+export interface RunResult {
+  gameName: string
+  categoryName: string
+  levelName: string | null
+  points: number
+  levelFraction: number
+}

--- a/models/core_models.py
+++ b/models/core_models.py
@@ -105,6 +105,19 @@ class Player(db.Model):
 
         return player
 
+    def update(self, **kwargs: Dict[str, Union[str, float, datetime]]) -> Player:
+        player = Player \
+            .query \
+            .filter(Player.user_id == self.user_id) \
+            .update(kwargs)
+        db.session.commit()
+        return player
+
+    def delete(self) -> bool:
+        db.session.delete(self)
+        db.session.commit()
+        return True
+
     def get_friends(self) -> List[Player]:
         sql = text("SELECT f.friend_id, p.name, p.country_code, p.score, p.last_update FROM friend f "
                    "JOIN player p ON p.user_id = f.friend_id "
@@ -158,7 +171,7 @@ class Player(db.Model):
         db.session.commit()
         return new_schedule.schedule_id
 
-    def update_schedule(self, schedule_id: int, name: str, is_active: bool, time_slots: List[Dict[str, Any]]) -> int:
+    def update_schedule(self, schedule_id: int, name: str, is_active: bool, time_slots: List[Dict[str, Any]]) -> bool:
         try:
             schedule_to_update = Schedule \
                 .query \

--- a/services/user_updater.py
+++ b/services/user_updater.py
@@ -189,7 +189,7 @@ def __set_user_points(user: User) -> None:
                for run in runs]
     start_and_wait_for_threads(threads)
 
-    # Sum up the runs' score, only the top 100 will end up giving points
+    # Sum up the runs' score, only the top 60 will end up giving points
     top_runs, lower_runs = extract_top_runs_and_score(counted_runs)
     user._points = sum(run._points for run in top_runs)
     user._point_distribution_str = "\n" + json.dumps([map_to_dto(top_runs), map_to_dto(lower_runs)])
@@ -238,7 +238,7 @@ def __set_run_points(self) -> None:
     # Shift the deviations up so that the worse time is now 0
     adjusted_deviation = signed_deviation + lowest_deviation
 
-    # CHECK: The last counted run isn't worth any points
+    # CHECK: The last counted run isn't worth any points, if this is 0 the rest of the formula will return 0
     if adjusted_deviation <= 0:
         return
 

--- a/services/user_updater.py
+++ b/services/user_updater.py
@@ -8,7 +8,7 @@ from time import strftime
 from typing import Dict, List, Union
 from threading import Thread
 from services.user_updater_helpers import BasicJSONType, extract_valid_personal_bests, get_probability_terms, \
-    get_subcategory_variables, keep_runs_before_soft_cutoff, keep_last_full_game_runs, MIN_LEADERBOARD_SIZE, \
+    get_subcategory_variables, keep_runs_before_soft_cutoff, MIN_LEADERBOARD_SIZE, \
     extract_top_runs_and_score, extract_sorted_valid_runs_from_leaderboard
 from services.utils import map_to_dto, SpeedrunComError, start_and_wait_for_threads, UserUpdaterError
 from urllib.parse import unquote
@@ -20,7 +20,6 @@ import requests
 import traceback
 
 TIME_BONUS_DIVISOR = 3600 * 12  # 12h (1/2 day) for +100%
-MAX_RUNS_COUNT = 1000
 SEPARATOR = "-" * 64
 
 
@@ -208,14 +207,6 @@ def __set_user_points(user: User) -> None:
         .format(user=user._id, pagesize=200)
     runs: List[BasicJSONType] = SrcRequest.get_paginated_response(url)["data"]
     runs = extract_valid_personal_bests(runs)
-
-    original_runs_count = len(runs)
-    if original_runs_count >= MAX_RUNS_COUNT:
-        runs = keep_last_full_game_runs(runs, MAX_RUNS_COUNT)
-
-        user._point_distribution_str = f"\nOnly kept the last {len(runs)} runs (out of {original_runs_count})." \
-            "\nDue to current limitations with PythonAnywhere and the speedrun.com api, " \
-            "fully updating such a user is nearly impossible."
 
     threads = [Thread(target=set_points_thread, args=(run,))
                for run in runs]

--- a/services/user_updater.py
+++ b/services/user_updater.py
@@ -20,7 +20,6 @@ import requests
 import traceback
 
 TIME_BONUS_DIVISOR = 3600 * 12  # 12h (1/2 day) for +100%
-SEPARATOR = "-" * 64
 
 
 def get_updated_user(p_user_id: str) -> Dict[str, Union[str, None, float, int]]:
@@ -32,7 +31,7 @@ def get_updated_user(p_user_id: str) -> Dict[str, Union[str, None, float, int]]:
 
     try:
         user = User(p_user_id)
-        print(f"{SEPARATOR}\n{user._name}")
+        print("Update request for: {user._name}")
 
         try:
             __set_user_code_and_name(user)
@@ -62,23 +61,28 @@ def get_updated_user(p_user_id: str) -> Dict[str, Union[str, None, float, int]]:
                     configs.bypass_update_restrictions:
 
                 __set_user_points(user)
+
                 if not threads_exceptions:
                     print(f"\nLooking for {user._id}")
                     text_output, result_state = update_runner_in_database(player, user)
                     text_output += user._point_distribution_str
                 else:
-                    error_str_list: List[str] = []
-                    for e in threads_exceptions:
-                        error_str_list.append("Error: {}\n{}".format(e["error"], e["details"]))
-                    error_str_counter = Counter(error_str_list)
-                    errors_str = "{0}" \
-                                 "\nhttps://github.com/Avasam/Global_Speedrunning_Scoreboard/issues" \
-                                 "\nNot uploading data as some errors were caught during execution:" \
-                                 "\n{0}\n".format(SEPARATOR)
-                    for error, count in error_str_counter.items():
-                        errors_str += f"[x{count}] {error}\n"
-                    text_output += ("\n" if text_output else "") + errors_str
-                    result_state = "danger"
+                    errors_str = "Please report to: https://github.com/Avasam/Global_Speedrunning_Scoreboard/issues\n" \
+                        "\nNot uploading data as some errors were caught during execution:\n"
+                    if len(threads_exceptions) == 1:
+                        raise UserUpdaterError({
+                            "error": threads_exceptions[0]["error"],
+                            "details": errors_str + threads_exceptions[0]["details"]})
+                    else:
+                        error_str_items = Counter(
+                            [f"Error: {e['error']}\n{e['details']}"
+                             for e in threads_exceptions]) \
+                            .items()
+                        for error, count in error_str_items:
+                            errors_str += f"[x{count}] {error}\n"
+                        raise UserUpdaterError({
+                            "error": "Multiple Unhandled Exceptions",
+                            "details": errors_str})
             else:
                 cant_update_time = configs.last_updated_days[0]
                 text_output = f"This user has already been updated in the past {cant_update_time} day" \
@@ -123,6 +127,10 @@ def __set_user_points(user: User) -> None:
 
     def set_points_thread(pb: BasicJSONType) -> None:
         try:
+            if threads_exceptions:
+                # Don't keep going if previous threads already threw something
+                print("Aborted thread due to previous thread exceptions")
+                return
             pb_subcategory_variables = get_subcategory_variables(pb)
 
             pb_level_id = pb["level"]["data"]["id"] if pb["level"]["data"] else ""

--- a/services/user_updater_helpers.py
+++ b/services/user_updater_helpers.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Tuple
 GAMETYPE_MULTI_GAME = "rj1dy1o8"
 BasicJSONType = Dict[str, Any]
 MIN_LEADERBOARD_SIZE = 3  # This is just to optimize as the formula gives 0 points to leaderboards size < 3
-MIN_SAMPLE_SIZE = 100
+MIN_SAMPLE_SIZE = 60
 
 
 def extract_valid_personal_bests(runs: List[BasicJSONType]) -> List[BasicJSONType]:

--- a/services/user_updater_helpers.py
+++ b/services/user_updater_helpers.py
@@ -110,14 +110,6 @@ def get_subcategory_variables(run: BasicJSONType) -> Dict[str, Dict[str, str]]:
     }
 
 
-def keep_last_full_game_runs(runs: List[BasicJSONType], max: int):
-    return sorted(
-        [run for run in runs if not run["level"]["data"]],
-        key=lambda run: run["date"],
-        reverse=True
-    )[:max]
-
-
 def get_probability_terms(pbs: List[BasicJSONType]):
     mean: float = 0.0
     sigma: float = 0.0


### PR DESCRIPTION
- Update for #151 Cap the runs that count for score at 60
- Better handling of exceptions in threads
- Updated in-code documentation and Readme
- Remove banned users from database
- Removed the 1000 runs limit since SRC improved their backend
- Fixed a pretty major issue with the formula that made it impossible for runs to be worth 0 to 1 point before decimal shifting. Last valid place in a leaderboard is supposed to be worth 0, not 1! This effectively removed 10 points from every full-game runs (a bit less for ILs)