### PR TITLE
Added region code support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -249,6 +249,12 @@
       }
     ],
     "@typescript-eslint/no-type-alias": "off",
+    // Note: These 2 drown TS2304 and actually make the errors harder to understand.
+    // See: https://github.com/typescript-eslint/typescript-eslint/issues/2665
+    // There's nothing we can do until a pedantic any check in TypeScript is added
+    // Eg.: https://github.com/microsoft/TypeScript/issues/40174
+    "@typescript-eslint/no-unsafe-call": "off",
+    "@typescript-eslint/no-unsafe-assignment": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
       {
@@ -413,6 +419,12 @@
     "no-dupe-else-if": "error",
     "no-inner-declarations": "error",
     "no-lonely-if": "error",
+    "no-multiple-empty-lines": [
+      "error",
+      {
+        "max": 1
+      }
+    ],
     "no-unneeded-ternary": "error",
     "no-warning-comments": [
       "warn",

--- a/Changescripts/2020-04-10-Added-country-code.sql
+++ b/Changescripts/2020-04-10-Added-country-code.sql
@@ -1,2 +1,2 @@
-ALTER TABLE `player` 
+ALTER TABLE `player`
 ADD COLUMN `country_code` VARCHAR(6) NULL AFTER `name`;

--- a/Changescripts/2020-05-11-Fixed-country-code-too-small.sql
+++ b/Changescripts/2020-05-11-Fixed-country-code-too-small.sql
@@ -1,2 +1,2 @@
-ALTER TABLE `player` 
+ALTER TABLE `player`
 MODIFY COLUMN `country_code` VARCHAR(6) NULL;

--- a/Changescripts/2020-05-12-Added-score-details.sql
+++ b/Changescripts/2020-05-12-Added-score-details.sql
@@ -1,2 +1,2 @@
-ALTER TABLE `player` 
+ALTER TABLE `player`
 ADD COLUMN `score_details` LONGTEXT NULL AFTER `score`;

--- a/Changescripts/2021-01-03-Added-deadline-to-schedule.sql
+++ b/Changescripts/2021-01-03-Added-deadline-to-schedule.sql
@@ -1,2 +1,2 @@
-ALTER TABLE `schedule` 
+ALTER TABLE `schedule`
 ADD COLUMN `deadline` DATETIME NULL AFTER `is_active`;

--- a/Changescripts/2021-03-25-Nullable-deadlines.sql
+++ b/Changescripts/2021-03-25-Nullable-deadlines.sql
@@ -1,2 +1,2 @@
-ALTER TABLE `schedule` 
+ALTER TABLE `schedule`
 CHANGE COLUMN `deadline` `deadline` DATETIME NULL ;

--- a/Changescripts/2021-06-01-Added_Region_Code_support.sql
+++ b/Changescripts/2021-06-01-Added_Region_Code_support.sql
@@ -1,0 +1,3 @@
+-- The biggest region code I found so far was "us/co/coloradosprings" at 21
+ALTER TABLE `player`
+CHANGE COLUMN `country_code` `country_code` VARCHAR(24) NULL DEFAULT NULL;

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Note: The soft cutoff works great on games such as Barney. But is too punishing 
 
 ## Dev environment setup
 
-Get yourself a [MySQL server](https://dev.mysql.com/downloads/mysql/) (PythonAnywhere uses version 5.6.40)  
-Install [Python](https://www.python.org/downloads/) 3.7+  
+Get yourself a [MySQL server](https://dev.mysql.com/downloads/mysql/) (as of 2021/06/01, PythonAnywhere uses version 5.7.27)  
+Install [Python](https://www.python.org/downloads/) 3.7 or 3.8 (but not 3.9 !)  
 Install PIP (this should come bundled with python 3.4+)  
 Run this command in a terminal: `pip3 install flask flask_cors flask_sqlalchemy sqlalchemy httplib2 simplejson mysql-connector requests pyjwt`  
 Copy `configs.template.py` as `configs.py` and update the file as needed.  

--- a/api/global_scoreboard_api.py
+++ b/api/global_scoreboard_api.py
@@ -18,7 +18,11 @@ api = Blueprint('global_scoreboard_api', __name__)
 
 @api.route('/players', methods=('GET',))
 def get_all_players():
-    return jsonify(map_to_dto(Player.get_all()))
+    country_code_str: Optional[str] = request.args.get('region')
+    if country_code_str is None:
+        return jsonify(map_to_dto(Player.get_all()))
+    country_codes = list(set(country_code_str.split(',')))
+    return jsonify(Player.get_by_country_code(country_codes)), 200, {'Access-Control-Allow-Origin': '*'}
 
 
 @api.route('/players/<id>/score-details', methods=('GET',))

--- a/configs.template.py
+++ b/configs.template.py
@@ -21,5 +21,5 @@ sql_track_modifications: bool = False
 sql_connector: str = "mysqlconnector"
 sql_username: str = "admin"
 sql_password: str = "admin"
-sql_hostname: str = "localhost:3356"
+sql_hostname: str = "localhost:3306"
 sql_database_name: str = "speedrun_global_scoreboard"

--- a/global-scoreboard/src/Dashboard/TableElements/PlayerNameCell.tsx
+++ b/global-scoreboard/src/Dashboard/TableElements/PlayerNameCell.tsx
@@ -11,6 +11,15 @@ type PlayerNameCellProps = {
   handleOnBefriend: (friendId: string) => void
 }
 
+const backupFlag = (element: HTMLImageElement) => {
+  const backupSrc = element.src.replace(/\/[a-z]+?\.png/, '.png')
+  if (backupSrc.endsWith('flags.png')) {
+    element.removeAttribute('src')
+  } else {
+    element.src = backupSrc
+  }
+}
+
 const PlayerNameCell = (props: PlayerNameCellProps) =>
   <span className='name-cell'>
     <a
@@ -23,6 +32,7 @@ const PlayerNameCell = (props: PlayerNameCellProps) =>
         alt=''
         className='flagicon'
         src={`https://www.speedrun.com/images/flags/${props.player.countryCode}.png`}
+        onError={err => backupFlag(err.currentTarget)}
       />}{props.player.name}</a>
     {
       !props.isCurrentUser &&

--- a/services/user_updater.py
+++ b/services/user_updater.py
@@ -113,11 +113,13 @@ def __set_user_code_and_name(user: User) -> None:
 
     user._id = infos["data"]["id"]
     location = infos["data"]["location"]
-    user._country_code = location["country"]["code"] if location else None
+    if location is not None:
+        country = location["country"]
+        region = location["region"]
+        user._country_code = region["code"] if region else country["code"]
+    else:
+        user._country_code = None
     user._name = infos["data"]["names"].get("international")
-    japanese_name = infos["data"]["names"].get("japanese")
-    if japanese_name:
-        user._name += f" ({japanese_name})"
     if infos["data"]["role"] == "banned":
         user._banned = True
         user._points = 0

--- a/services/user_updater_helpers.py
+++ b/services/user_updater_helpers.py
@@ -216,6 +216,7 @@ def update_runner_in_database(player: Player, user: User):
             else:
                 text_output = f"{user} found. Updated their entry."
                 result_state = "success"
+            print(user._country_code)
             player.update(name=user._name,
                           country_code=user._country_code,
                           score=floor(user._points),


### PR DESCRIPTION
- Extended countryCode field in DB
- Get region code first, fallback to country code
- Add an endpoint to get users filtered by region (for NoReset)
- Removed Japanese name support as it's now always null
- Ensured if a flag doesn't exist for a region, that it would fallback to showing the parent region's flag
- Fixed country code not being set for new users
- This also lays the logical foundations for #146